### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You should be able to run it if you copy xflr5_3dprinting.exe from the root of t
 After you run this version you can open your project and select "Export to STL" in the R click menu from the wing name in the Object Explorer (see images below)
 The stl output can be opened in your favorite printing or editing software (Prusa, Blender, etc)
 
-Currently hardcoded only (ie you can only use if you open the source with QT Creater and edit the code yourself):-
+Currently hardcoded only (ie you can only use if you open the source with Qt Creator and edit the code yourself):-
    Spar cutouts or printing (at approx line 4350 in xflr5\xflr5v6\xflobjects\objects3d\wings.cpp)
    Drainage holes for resin printers (just below spars in the code)
 

--- a/XFoil-lib/xfoil.cpp
+++ b/XFoil-lib/xfoil.cpp
@@ -69,7 +69,7 @@ XFoil::XFoil()
     xstrip[1] = 1.0;
     xstrip[2] = 1.0;
 
-    //intialize analysis parameter  until user changes them
+    //initialize analysis parameter until user changes them
     //---- default paneling parameters
     npan = 140;
     cvpar = 1.0;
@@ -6197,7 +6197,7 @@ stop12:
     //---- dpsi/dalfa
     z_alfa += - qinf*(sina*yi + cosa*xi);
 
-    //techwinder: removed image calculattion
+    //techwinder: removed image calculation
     return false;
 }
 
@@ -8089,7 +8089,7 @@ void XFoil::sss(double ss, double *s1, double *s2, double del, double xbf, doubl
 //     returns the arc length values s1,s2 of the endpoints
 //     of the airfoil surface segment which "disappears" as a
 //     result of the flap deflection.  the line segments between
-//     these enpoints and the flap hinge point (xbf,ybf) have
+//     these endpoints and the flap hinge point (xbf,ybf) have
 //     an included angle of del.  del is therefore the flap
 //     deflection which will join up the points at s1,s2.
 //     ss is an approximate arc length value near s1 and s2.
@@ -8199,7 +8199,7 @@ void XFoil::sss(double ss, double *s1, double *s2, double del, double xbf, doubl
             a11 =  r1_s1 *sind + ssgn;
             a12 =  r2_s2 *sind - ssgn;
 
-            //------- residual 2: set vector sum of line segments beteen the
+            //------- residual 2: set vector sum of line segments between the
             //-       endpoints and flap hinge to be perpendicular to airfoil surface.
             x1pp = d2val(*s1,x,xp,s,n);
             y1pp = d2val(*s1,y,yp,s,n);
@@ -12244,7 +12244,7 @@ bool XFoil::mixed(int kqsp)
             }
         }
 
-        //---- update gloabal variables
+        //---- update global variables
         psio  = psio  + dq[n+1];
         qdof0 = qdof0 + dq[n+2];
         qdof1 = qdof1 + dq[n+3];

--- a/XFoil-lib/xfoil.h
+++ b/XFoil-lib/xfoil.h
@@ -734,7 +734,7 @@ c   limage      .true. if image airfoil is present
 c   lgamu       .true. if gamu  arrays exist for current airfoil geometry
 c   lqinu       .true. if qinvu arrays exist for current airfoil geometry
 c   lvisc       .true. if viscous option is invoked
-c   lalfa       .true. if alpha is specifed, .false. if cl is specified
+c   lalfa       .true. if alpha is specified, .false. if cl is specified
 c   lwake       .true. if wake geometry has been calculated
 c   lpacc       .true. if each point calculated is to be saved
 c   lblini      .true. if bl has been initialized

--- a/doc/xflr5-guidelines_latex/guidelines_en.tex
+++ b/doc/xflr5-guidelines_latex/guidelines_en.tex
@@ -41,7 +41,7 @@
 %-----PAGE LAYOUT---------------------
 % http://www.ctan.org/tex-archive/macros/latex/contrib/fancyhdr/fancyhdr.pdf
 % http://amath.colorado.edu/documentation/LaTeX/reference/layout.html
-% Lot of other ressources about Latex page layout on the web ...
+% Lot of other resources about Latex page layout on the web ...
 
 %-header and footer-
 \pagestyle{fancy}
@@ -531,7 +531,7 @@ This foil design mode, however, may be useful to overlay different
 foils and compare their geometries.
 
 An option has been added in v6 to load a background image, with the
-idea of digitalizing existing foils.
+idea of digitizing existing foils.
 
 \subsubsection{B-splines main features}
 
@@ -735,7 +735,7 @@ Two options are provided, for two different purposes :
 \begin{enumerate}
 \item Representation by flat panels : this is the "Analysis"
 purpose. \newline
-Given an existing body, the idea is to digitalize its geometry and
+Given an existing body, the idea is to digitize its geometry and
 input it in XFLR5. The resulting geometry will not be smooth, but it
 is usually enough for prediction pruposes
 \item Representation by B-Splines : this is the "Design"
@@ -775,7 +775,7 @@ BODYTYPE
 
 \begin{itemize}
 \item The keywords should be preceded by the character '\#'.
-\item n is the number of side point definining the frame. This number
+\item n is the number of side point defining the frame. This number
 must be the same for all frame. If the frames are defined with
 different numbers of points, the frame last defined will set the
 number of points.

--- a/doc/xflr5-guidelines_latex/pagelayout.tex
+++ b/doc/xflr5-guidelines_latex/pagelayout.tex
@@ -2,7 +2,7 @@
 %-----PAGE LAYOUT---------------------
 % http://www.ctan.org/tex-archive/macros/latex/contrib/fancyhdr/fancyhdr.pdf
 % http://amath.colorado.edu/documentation/LaTeX/reference/layout.html
-% Lot of other ressources about Latex page layout on the web ...
+% Lot of other resources about Latex page layout on the web ...
 
 %-header and footer-
 \pagestyle{fancy}

--- a/xflr5v6/design/afoil.cpp
+++ b/xflr5v6/design/afoil.cpp
@@ -1283,7 +1283,7 @@ void AFoil::saveSettings(QSettings &settings)
 
 /**
  * The user has requested the context menu associated to the Foil table.
- * @param position the right-click positon
+ * @param position the right-click position
  */
 void AFoil::onFoilTableCtxMenu(const QPoint &)
 {

--- a/xflr5v6/globals/mainframe.cpp
+++ b/xflr5v6/globals/mainframe.cpp
@@ -4363,7 +4363,7 @@ bool MainFrame::serializePlaneProject(QDataStream &ar)
     ar << Units::forceUnitIndex();
     ar << Units::momentUnitIndex();
 
-    //Save default Polar data. Not in the Settings, since this is Project dependant
+    //Save default Polar data. Not in the Settings, since this is Project dependent
     if     (WPolarDlg::s_WPolar.polarType()==xfl::FIXEDSPEEDPOLAR) ar<<1;
     else if(WPolarDlg::s_WPolar.polarType()==xfl::FIXEDLIFTPOLAR)  ar<<2;
     else if(WPolarDlg::s_WPolar.polarType()==xfl::FIXEDAOAPOLAR)   ar<<4;
@@ -4743,7 +4743,7 @@ bool MainFrame::serializeProjectXFL(QDataStream &ar, bool bIsStoring)
 
         if(ArchiveFormat==200001)
         {
-            //Load the default Polar data. Not in the Settings, since this is Project dependant
+            //Load the default Polar data. Not in the Settings, since this is Project dependent
             ar >> n;
             switch (n)
             {
@@ -4868,7 +4868,7 @@ bool MainFrame::serializeProjectXFL(QDataStream &ar, bool bIsStoring)
             if(serializeFoilXFL(pFoil, ar, bIsStoring))
             {
                 // delete any former foil with that name - necessary in the case of project insertion to avoid duplication
-                // there is a risk that old plane results are not consisent with the new foil, but difficult to avoid that
+                // there is a risk that old plane results are not consistent with the new foil, but difficult to avoid that
                 Foil *pOldFoil = Objects2d::foil(pFoil->name());
                 if(pOldFoil) Objects2d::deleteFoil(pOldFoil);
                 Objects2d::appendFoil(pFoil);
@@ -5079,7 +5079,7 @@ bool MainFrame::serializeProjectWPA(QDataStream &ar, bool bIsStoring)
         {
             pWPolar = new WPolar;
             bWPolarOK = pWPolar->serializeWPlrWPA(ar, bIsStoring);
-            //force compatibilty
+            //force compatibility
             if(pWPolar->analysisMethod()==xfl::PANEL4METHOD && pWPolar->polarType()==xfl::STABILITYPOLAR)
                 pWPolar->setThinSurfaces(true);
 

--- a/xflr5v6/gui_objects/splinefoil.cpp
+++ b/xflr5v6/gui_objects/splinefoil.cpp
@@ -26,7 +26,7 @@
 #include <xflobjects/objects_global.h>
 
 /**
- * The public costructor.
+ * The public constructor.
  */
 SplineFoil::SplineFoil()
 {
@@ -89,7 +89,7 @@ void SplineFoil::initSplineFoil()
 }
 
 /**
- * Calculates the SplineFoil's mid-camber line and stores the resutls in the memeber array.
+ * Calculates the SplineFoil's mid-camber line and stores the resutls in the member array.
  * @return
  */
 void SplineFoil::compMidLine()
@@ -399,7 +399,7 @@ void SplineFoil::updateSplineFoil()
  * @param painter a reference to the QPainter object with which to draw
  * @param scalex the scale of the view in the x direction
  * @param scaley the scale of the view in the y direction
- * @param Offset the postion of the SplineFoil's leading edge point
+ * @param Offset the position of the SplineFoil's leading edge point
  */
 void SplineFoil::drawCtrlPoints(QPainter &painter, double scalex, double scaley, QPointF Offset)
 {
@@ -412,7 +412,7 @@ void SplineFoil::drawCtrlPoints(QPainter &painter, double scalex, double scaley,
  * @param painter a reference to the QPainter object with which to draw
  * @param scalex the scale of the view in the x direction
  * @param scaley the scale of the view in the y direction
- * @param Offset the postion of the SplineFoil's leading edge point
+ * @param Offset the position of the SplineFoil's leading edge point
  */
 void SplineFoil::drawOutPoints(QPainter & painter, double scalex, double scaley, QPointF Offset)
 {
@@ -425,7 +425,7 @@ void SplineFoil::drawOutPoints(QPainter & painter, double scalex, double scaley,
  * @param painter a reference to the QPainter object with which to draw
  * @param scalex the scale of the view in the x direction
  * @param scaley the scale of the view in the y direction
- * @param Offset the postion of the SplineFoil's leading edge point
+ * @param Offset the position of the SplineFoil's leading edge point
  */
 void SplineFoil::drawFoil(QPainter &painter, double scalex, double scaley, QPointF Offset)
 {
@@ -439,7 +439,7 @@ void SplineFoil::drawFoil(QPainter &painter, double scalex, double scaley, QPoin
  * @param painter a reference to the QPainter object with which to draw
  * @param scalex the scale of the view in the x direction
  * @param scaley the scale of the view in the y direction
- * @param Offset the postion of the SplineFoil's leading edge point
+ * @param Offset the position of the SplineFoil's leading edge point
  */
 void SplineFoil::drawMidLine(QPainter &painter, double scalex, double scaley, QPointF Offset)
 {

--- a/xflr5v6/gui_objects/splinefoil.h
+++ b/xflr5v6/gui_objects/splinefoil.h
@@ -37,7 +37,7 @@
 *@class SplineFoil
 *@brief  The class which defines the splined foil object.
 
-The foil is contructed based on one spline for the upper surface and one spline for the lower surface.
+The foil is constructed based on one spline for the upper surface and one spline for the lower surface.
 */
 class SplineFoil : public XflObject
 {
@@ -92,11 +92,11 @@ class SplineFoil : public XflObject
 
     private:
         bool m_bModified;                /**< false if the SplineFoil has been serialized in its current dtate, false otherwise */
-        bool m_bOutPoints;               /**< true if the ouput line points should be displayed */
+        bool m_bOutPoints;               /**< true if the output line points should be displayed */
         bool m_bCenterLine;              /**< true if the SplineFoil's mean camber line is to be displayed */
         bool m_bSymetric;                /**< true if the SplineFoil is symetric. In which case the lower surface is set as symetric of the upper surface. */
         bool m_bForceCloseLE;            /**< true if the leading end points of the top and bottom spline should be positioned at the same place */
-        bool m_bForceCloseTE;            /**< true if the traling end points of the top and bottom spline should be positioned at the same place */
+        bool m_bForceCloseTE;            /**< true if the trailing end points of the top and bottom spline should be positioned at the same place */
         int m_OutPoints;                 /**< the number of output points with which to draw the SplineFoil. */
 
 

--- a/xflr5v6/miarex/analysis/lltanalysisdlg.h
+++ b/xflr5v6/miarex/analysis/lltanalysisdlg.h
@@ -59,7 +59,7 @@ class PlaneTask;
   - stores the results in the OpPoint and Polar objects
   - updates the display in the Miarex view.
 
- The LLTAnalysis class performs the calculation of a signle OpPoint. The loop over a sequence of aoa, Cl, or Re values
+ The LLTAnalysis class performs the calculation of a single OpPoint. The loop over a sequence of aoa, Cl, or Re values
  are performed in the LLAnalysisDlg Class.
 */
 class LLTAnalysisDlg : public QDialog
@@ -109,7 +109,7 @@ class LLTAnalysisDlg : public QDialog
         bool m_bCancel;             /**< true if the user has cancelled the analysis */
         bool m_bFinished;           /**< true if the analysis is completed, false if it is running */
         Graph *m_pIterGraph;         /**< A pointer to the QGraph object where the progress of the iterations are displayed */
-        QPoint m_LegendPlace;       /**< The position where the legend should be diplayed in the output graph */
+        QPoint m_LegendPlace;       /**< The position where the legend should be displayed in the output graph */
         QRect m_ViscRect;           /**< The rectangle in the client area where the graph is displayed */
 
         QString m_strOut;

--- a/xflr5v6/miarex/analysis/wpolardlg.h
+++ b/xflr5v6/miarex/analysis/wpolardlg.h
@@ -42,7 +42,7 @@ class CtrlTableDelegate;
 
 /**
 *@class WPolarDlg
-*@brief This class provides the interface dialog box which is used to define or to edit the paramaters of a type 1, 2 or 4 polar.
+*@brief This class provides the interface dialog box which is used to define or to edit the parameters of a type 1, 2 or 4 polar.
 
 * The class uses a static instance of the WPolar class as the default data. 
 * This is so that the next call to the class uses the existing data, and only modifications are required.

--- a/xflr5v6/miarex/analysis/wpolardlg.h.mine
+++ b/xflr5v6/miarex/analysis/wpolardlg.h.mine
@@ -43,7 +43,7 @@ class CtrlTableDelegate;
 
 /**
 *@class WPolarDlg
-*@brief This class provides the interface dialog box which is used to define or to edit the paramaters of a type 1, 2 or 4 polar.
+*@brief This class provides the interface dialog box which is used to define or to edit the parameters of a type 1, 2 or 4 polar.
 
 * The class uses a static instance of the WPolar class as the default data. 
 * This is so that the next call to the class uses the existing data, and only modifications are required.

--- a/xflr5v6/miarex/analysis/wpolardlg.h.r1240
+++ b/xflr5v6/miarex/analysis/wpolardlg.h.r1240
@@ -43,7 +43,7 @@ class CtrlTableDelegate;
 
 /**
 *@class WPolarDlg
-*@brief This class provides the interface dialog box which is used to define or to edit the paramaters of a type 1, 2 or 4 polar.
+*@brief This class provides the interface dialog box which is used to define or to edit the parameters of a type 1, 2 or 4 polar.
 
 * The class uses a static instance of the WPolar class as the default data. 
 * This is so that the next call to the class uses the existing data, and only modifications are required.

--- a/xflr5v6/miarex/analysis/wpolardlg.h.r1247
+++ b/xflr5v6/miarex/analysis/wpolardlg.h.r1247
@@ -43,7 +43,7 @@ class CtrlTableDelegate;
 
 /**
 *@class WPolarDlg
-*@brief This class provides the interface dialog box which is used to define or to edit the paramaters of a type 1, 2 or 4 polar.
+*@brief This class provides the interface dialog box which is used to define or to edit the parameters of a type 1, 2 or 4 polar.
 
 * The class uses a static instance of the WPolar class as the default data. 
 * This is so that the next call to the class uses the existing data, and only modifications are required.

--- a/xflr5v6/miarex/miarex.cpp
+++ b/xflr5v6/miarex/miarex.cpp
@@ -1443,7 +1443,7 @@ void Miarex::fillWOppCurve(WingOpp const *pWOpp, Graph *pGraph, Curve *pCurve)
 
 
 /**
-* Fills the curve of the stability graph with the data from the pWPolar oject for the seleted mode
+* Fills the curve of the stability graph with the data from the pWPolar object for the selected mode
 *@param pCurve  a pointer to the instance of the CCurve object to be filled with the data from the CWPolar object
 *@param pWPolar a pointer to the instance of the CWPolar object from which the data is to be extracted
 *@param iMode the index of the mode for which the curve is to be created
@@ -2438,7 +2438,7 @@ void Miarex::onAnimateWOppSingle()
 
 
 /**
-* Modfies the animation after the user has changed the animation speed for the WOpp display
+* Modifies the animation after the user has changed the animation speed for the WOpp display
 */
 void Miarex::onAnimateWOppSpeed(int val)
 {
@@ -5280,7 +5280,7 @@ void Miarex::onRenameCurWPolar()
 
 
 /**
- * The user has requested that the active wing ot plane be renames
+ * The user has requested that the active wing of plane be renamed
  * Changes the name and updates the references in all child polars and oppoints
  */
 void Miarex::onRenameCurPlane()
@@ -5353,7 +5353,7 @@ void Miarex::onResetCurWPolar()
 
 
 /**
- * The user has toggled the switch for a sequential analyis
+ * The user has toggled the switch for a sequential analysis
  */
 void Miarex::onSequence()
 {
@@ -5787,7 +5787,7 @@ void Miarex::onStoreWOpp()
 
 /**
  * The user has toggled the display of the curves for the second wing in case of a bi-plane
- *@todo not thouroughly tested
+ *@todo not thoroughly tested
  */
 void Miarex::onWing2Curve()
 {
@@ -6252,7 +6252,7 @@ void Miarex::paintPlaneOppLegend(QPainter &painter, QRect drawRect)
 /**
  * Saves the user settings to the QSettings object
  * @param pSettings a pointer to the QSettings object
- * @return true if the save was successfull, false if an error was encountered
+ * @return true if the save was successful, false if an error was encountered
  */
 bool Miarex::saveSettings(QSettings &settings)
 {
@@ -7523,7 +7523,7 @@ void Miarex::drawColorGradient(QPainter &painter, QRect const & gradientRect)
 
 
 /**
-* Searches for an operating point with aoa or velocity or control paramter x, for the active polar
+* Searches for an operating point with aoa or velocity or control parameter x, for the active polar
 * Sets it as active, if valid
 * else sets the current PlaneOpp, if any
 * else sets the comboBox's first, if any

--- a/xflr5v6/miarex/miarex.h
+++ b/xflr5v6/miarex/miarex.h
@@ -80,7 +80,7 @@ class gl3dMiarexView;
     - Construction of the panels for 3D calculations
     - Management of the display
     - Management of the LLT and Panel Analysis,
-    - Mapping of the analyis results to the operating point and polar objects
+    - Mapping of the analysis results to the operating point and polar objects
 */
 class Miarex : public QWidget
 {
@@ -368,7 +368,7 @@ class Miarex : public QWidget
         bool m_bShowCp;                    /**< true if the active curve should be displayed in Cp view */
         bool m_bShowEllipticCurve;         /**< true if the elliptic loading should be displayed in the local lift graph */
         bool m_bShowBellCurve;             /**< true if the bell distribution loading should be displayed in the local lift graph */
-        bool m_bShowWingCurve[MAXWINGS];   /**< true if various plane's wing curves shoud be displayed*/
+        bool m_bShowWingCurve[MAXWINGS];   /**< true if various plane's wing curves should be displayed*/
         bool m_bShowFlapMoments;           /**< true if the flap moment values should be display together with the operating point results*/
         bool m_bTrans;                     /**< true if the view is being dragged */
         bool m_bTransGraph;                   /**< true if a graph is being dragged */

--- a/xflr5v6/miarex/view/gl3dmiarexview.cpp
+++ b/xflr5v6/miarex/view/gl3dmiarexview.cpp
@@ -142,7 +142,7 @@ void gl3dMiarexView::glRenderView()
         //apply aoa rotation
         m_matModel.rotate(float(pPOpp->alpha()),0.0,1.0,0.0);
 
-        /* CP position alredy includes the sideslip geometry, shond't be rotated by sideslip*/
+        /* CP position already includes the sideslip geometry, shond't be rotated by sideslip*/
         if(s_pMiarex->m_bXCP)
         {
             for(int iw=0; iw<MAXWINGS; iw++)

--- a/xflr5v6/misc/options/settingswt.h
+++ b/xflr5v6/misc/options/settingswt.h
@@ -105,7 +105,7 @@ class Settings : public QWidget
         static bool s_bStyleSheet;
 
         static xfl::enumTextFileType s_ExportFileType;  /**< Defines if the list separator for the output text files should be a space or a comma. */
-        static Graph s_RefGraph;//Reference setttings
+        static Graph s_RefGraph;//Reference settings
         static QStringList s_colorList;
         static QStringList s_colorNames;
         static bool s_bDontUseNativeDlg;

--- a/xflr5v6/misc/stlexportdialog.cpp
+++ b/xflr5v6/misc/stlexportdialog.cpp
@@ -100,7 +100,7 @@ void STLExportDlg::setupLayout()
         }
 
 
-        QGroupBox *pDimensionsBox = new QGroupBox(tr("3D printable dimensions (mm *NOT* metres for printer compatability)"));
+        QGroupBox *pDimensionsBox = new QGroupBox(tr("3D printable dimensions (mm *NOT* metres for printer compatibility)"));
         {
             QVBoxLayout *pDimensionsLayout = new QVBoxLayout;
             {

--- a/xflr5v6/xdirect/analysis/batchabstractdlg.cpp
+++ b/xflr5v6/xdirect/analysis/batchabstractdlg.cpp
@@ -81,7 +81,7 @@ int BatchAbstractDlg::s_nThreads = 1;
 QByteArray BatchAbstractDlg::s_Geometry;
 
 /**
- * The public contructor
+ * The public constructor
  */
 BatchAbstractDlg::BatchAbstractDlg(QWidget *pParent) : QDialog(pParent)
 {
@@ -447,7 +447,7 @@ void BatchAbstractDlg::initDialog()
 
 
 /**
- * The user has switched between aoa and lift coeficient.
+ * The user has switched between aoa and lift coefficient.
  * Initializes the interface with the corresponding values.
  */
 void BatchAbstractDlg::onAcl()

--- a/xflr5v6/xdirect/analysis/batchgraphdlg.cpp
+++ b/xflr5v6/xdirect/analysis/batchgraphdlg.cpp
@@ -268,7 +268,7 @@ void BatchGraphDlg::alphaLoop()
 
 
 /**
- * Cleans up the GUI and paramters at the end of the Analysis.
+ * Cleans up the GUI and parameters at the end of the Analysis.
  */
 void BatchGraphDlg::cleanUp()
 {
@@ -563,7 +563,7 @@ void BatchGraphDlg::readParams()
  * Loops through all the specified Relist, and for each element of the list:
  *  - creates a Polar object
  *  - initializes the XFoilTask object
- *  - launches the XFoilTask whcih will loop over the specified aoa or Cl range
+ *  - launches the XFoilTask which will loop over the specified aoa or Cl range
  */
 void BatchGraphDlg::ReLoop()
 {

--- a/xflr5v6/xdirect/analysis/batchthreaddlg.cpp
+++ b/xflr5v6/xdirect/analysis/batchthreaddlg.cpp
@@ -35,7 +35,7 @@
 
 
 /**
- * The public contructor
+ * The public constructor
  */
 BatchThreadDlg::BatchThreadDlg(QWidget *pParent) : BatchAbstractDlg(pParent)
 {
@@ -299,7 +299,7 @@ void BatchThreadDlg::startThread()
 
 
 /**
- * Adds a text message to the ouput widget
+ * Adds a text message to the output widget
  * @param str the message to output
  */
 void BatchThreadDlg::updateOutput(QString const&str)

--- a/xflr5v6/xdirect/analysis/xfoiltask.cpp
+++ b/xflr5v6/xdirect/analysis/xfoiltask.cpp
@@ -66,7 +66,7 @@ XFoilTask::XFoilTask(QObject *pParent)
 
 /**
 * Implements the run method of the QRunnable virtual base method
-* Asssumes that XFoil has been initialized with Foil and Polar
+* Assumes that XFoil has been initialized with Foil and Polar
 */
 void XFoilTask::run()
 {
@@ -93,7 +93,7 @@ void XFoilTask::run()
 * Initializes the XFoil calculation
 * @param pFoil a pointer to the instance of the Foil object for which the calculation is run
 * @param pPolar a pointer to the instance of the Polar object for which the calculation is run
-* @return true if the initialization of the Foil in XFoil has been sucessful, false otherwise
+* @return true if the initialization of the Foil in XFoil has been successful, false otherwise
 */
 bool XFoilTask::initializeTask(FoilAnalysis &foilanalysis, bool bViscous, bool bInitBL, bool bFromZero)
 {
@@ -105,7 +105,7 @@ bool XFoilTask::initializeTask(FoilAnalysis &foilanalysis, bool bViscous, bool b
 * Initializes the XFoil calculation
 * @param pFoil a pointer to the instance of the Foil object for which the calculation is run
 * @param pPolar a pointer to the instance of the Polar object for which the calculation is run
-* @return true if the initialization of the Foil in XFoil has been sucessful, false otherwise
+* @return true if the initialization of the Foil in XFoil has been successful, false otherwise
 */
 bool XFoilTask::initializeXFoilTask(Foil const*pFoil, Polar *pPolar, bool bViscous, bool bInitBL, bool bFromZero)
 {

--- a/xflr5v6/xdirect/geometry/foilgeomdlg.cpp
+++ b/xflr5v6/xdirect/geometry/foilgeomdlg.cpp
@@ -353,7 +353,7 @@ void FoilGeomDlg::keyPressEvent(QKeyEvent *pEvent)
 
 void FoilGeomDlg::initDialog()
 {
-    // round values to be consistend to entry field value decimals
+    // round values to be consistent to entry field value decimals
     m_fCamber     = round (m_pMemFoil->camber()     * 10000) / 10000 ;
     m_fThickness  = round (m_pMemFoil->thickness()  * 10000) / 10000 ;
     m_fXCamber    = round (m_pMemFoil->xCamber()    * 10000) / 10000 ;

--- a/xflr5v6/xdirect/oppointwt.h
+++ b/xflr5v6/xdirect/oppointwt.h
@@ -102,8 +102,8 @@ class OpPointWt : public QWidget
         bool m_bTransFoil;
         bool m_bTransGraph;
         bool m_bAnimate;
-        bool m_bBL;                /**< true if the Boundary layer shoud be displayed */
-        bool m_bPressure;          /**< true if the pressure distirbution should be displayed */
+        bool m_bBL;                /**< true if the Boundary layer should be displayed */
+        bool m_bPressure;          /**< true if the pressure distribution should be displayed */
         bool m_bNeutralLine;
 
         bool m_bXPressed;                  /**< true if the X key is pressed */

--- a/xflr5v6/xdirect/optim2d/mopsotask.cpp
+++ b/xflr5v6/xdirect/optim2d/mopsotask.cpp
@@ -105,7 +105,7 @@ void MOPSOTask::onSwarm()
     if(m_Swarm.size()==0 || m_Swarm.size()!=s_PopSize)
     {
         outputMsg("Swarm has not been created\n");
-        postPSOEvent(-1); // notifiy finished
+        postPSOEvent(-1); // notify finished
         moveToThread(QApplication::instance()->thread());
         return;
     }

--- a/xflr5v6/xdirect/optim2d/mopsotask2d.h
+++ b/xflr5v6/xdirect/optim2d/mopsotask2d.h
@@ -52,7 +52,7 @@ class MOPSOTask2d : public MOPSOTask
 
         double m_HHt2;     /**< t2 parameter of the HH functions */
         int    m_HHn;      /**< number of HH functions to use */
-        double m_HHmax;    /**< the max amplitude of the HH functions - unused and deined by the variable's amplitude*/
+        double m_HHmax;    /**< the max amplitude of the HH functions - unused and denied by the variable's amplitude*/
         double m_Alpha;
 
 };

--- a/xflr5v6/xdirect/xdirect.cpp
+++ b/xflr5v6/xdirect/xdirect.cpp
@@ -3739,7 +3739,7 @@ void XDirect::onShowPolarOpps()
 
 
 /**
- * The user has toggled the switch used to define the type of input parameter bewteen aoa, Cl, and Re
+ * The user has toggled the switch used to define the type of input parameter between aoa, Cl, and Re
  */
 void XDirect::onSpec()
 {

--- a/xflr5v6/xdirect/xdirect.h
+++ b/xflr5v6/xdirect/xdirect.h
@@ -276,7 +276,7 @@ class XDirect : public QWidget
 
         int m_posAnimate;          /**< the current aoa in the animation */
 
-        int m_iPlrGraph;           /**< defines whch polar graph is selected if m_iPlrView=1 */
+        int m_iPlrGraph;           /**< defines which polar graph is selected if m_iPlrView=1 */
         xfl::enumGraphView m_iPlrView;  /**< defines the number of graphs to be displayed in the polar view */
 
         QVector<Foil*> *m_poaFoil;    /**< pointer to the foil object array */
@@ -294,7 +294,7 @@ class XDirect : public QWidget
         static bool s_bViscous;           /**< true if performing a viscous calculation, false if inviscid */
         static bool s_bAlpha;             /**< true if performing an analysis based on aoa, false if based on Cl */
         static bool s_bInitBL;            /**< true if the boundary layer should be initialized for the next xfoil calculation */
-        static bool s_bKeepOpenErrors;    /**< true if the XfoilAnalysisDlg should be kept open if errors occured in the XFoil calculation */
+        static bool s_bKeepOpenErrors;    /**< true if the XfoilAnalysisDlg should be kept open if errors occurred in the XFoil calculation */
         static int s_TimeUpdateInterval;  /**< time interval in ms between two output display updates during an XFoil analysis */
         static QVector<double> s_ReList;        /**< the user-defined list of Re numbers, used for batch analysis */
         static QVector<double> s_MachList;      /**< the user-defined list of Mach numbers, used for batch analysis */

--- a/xflr5v6/xfl3d/testgl/gl3dsolarsys.cpp
+++ b/xflr5v6/xfl3d/testgl/gl3dsolarsys.cpp
@@ -314,7 +314,7 @@ void gl3dSolarSys::glMake3dObjects()
 
         // make Halley's ellipse
         double a = 17.834 * 1.495978707e11; // semi-major axis length
-        double e = 0.96714; //excentricity
+        double e = 0.96714; //eccentricity
         glMakeEllipseFan(a/SCALEFACTOR, e, Vector3d(), m_vboHalleyEllipse);
 
        m_bResetPlanet = false;
@@ -506,7 +506,7 @@ void gl3dSolarSys::makePlanets()
 
     m_Halley.m_Radius = 1.0; // whatever
     m_Halley.m_a = 17.834 * 1.495978707e11; // semi-major axis length
-    m_Halley.m_e = 0.96714; //excentricity
+    m_Halley.m_e = 0.96714; //eccentricity
     m_Halley.m_i = -180.0f+162.26f;
     m_Halley.m_omega = 111.33;
     Distance = m_Halley.m_a*(m_Halley.m_e+1.0); // apogee distance to Sun

--- a/xflr5v6/xfl3d/testgl/spaceobject.cpp
+++ b/xflr5v6/xfl3d/testgl/spaceobject.cpp
@@ -26,7 +26,7 @@ Planet::Planet()
     m_Color.setHsv(h,s,v,255);
 
     m_a      = 0;        // semi-major axis
-    m_e      = 0;        // excentricity
+    m_e      = 0;        // eccentricity
     m_i      = 0;        // inclination
     m_Omega  = 0;    // longitude of the ascending node
     m_omega  = 0;    // argument of periapsis

--- a/xflr5v6/xfl3d/testgl/spaceobject.h
+++ b/xflr5v6/xfl3d/testgl/spaceobject.h
@@ -70,7 +70,7 @@ class Planet
 
         //standard orbital elements https://en.wikipedia.org/wiki/Orbital_elements
         double m_a;        // semi-major axis
-        double m_e;        // excentricity
+        double m_e;        // eccentricity
         double m_i;        // inclination
         double m_Omega;    // longitude of the ascending node
         double m_omega;    // argument of periapsis

--- a/xflr5v6/xflanalysis/plane_analysis/lltanalysis.cpp
+++ b/xflr5v6/xflanalysis/plane_analysis/lltanalysis.cpp
@@ -396,9 +396,9 @@ void LLTAnalysis::setBending(double QInf)
 /**
  * Calculates the linear solution to the Lifting line problem, for the given wing geometry and angle of attack.
  * This is the starting point for the non-linear iterations.
- * A simplifying assumtion is that the lift slope is Cl = 2.pi (alpha-alpha0+wahshout) at all positions.
+ * A simplifying assumption is that the lift slope is Cl = 2.pi (alpha-alpha0+wahshout) at all positions.
  * Numerical experiments have shown however that the non-linear LLT converges in roughly the same amount of iterations
- * whatever the initial state, even if random or asymetric.
+ * whatever the initial state, even if random or asymmetric.
  * @param Alpha the angle of attack, in degrees
  * @return true if a linear solution has been set, false otherwise. Should always be true, unless the user has defined some crazy wing configuration. Who knows what a user can do ?
  */

--- a/xflr5v6/xflanalysis/plane_analysis/lltanalysis.h
+++ b/xflr5v6/xflanalysis/plane_analysis/lltanalysis.h
@@ -191,7 +191,7 @@ private:
     static int s_NLLTStations;                  /**< The number of LLT stations in the spanwise direction */
     static double s_RelaxMax;                   /**< The relaxation factor for the iterations */
     static double s_CvPrec;                     /**< Precision criterion to stop the iterations. The difference in induced angle at any span point between two iterations should be less than the criterion */
-    static bool s_bInitCalc;                    /**< true if the iterations analysis should be intialized with the linear solution at each new a.o.a. calculation, false otherwise */
+    static bool s_bInitCalc;                    /**< true if the iterations analysis should be initialized with the linear solution at each new a.o.a. calculation, false otherwise */
 
     QVector<PlaneOpp*> m_PlaneOppList;
     QVector<Polar*> const *m_poaPolar;

--- a/xflr5v6/xflanalysis/plane_analysis/panelanalysis.cpp
+++ b/xflr5v6/xflanalysis/plane_analysis/panelanalysis.cpp
@@ -1039,7 +1039,7 @@ void PanelAnalysis::createWakeContribution()
 *    - follow the method described in NASA 4023 eq. (44)
 *    - add the wake's doublet contribution to the matrix
 *    - add the potential difference at the trailing edge panels to the RHS ; the potential's origin
-*     is set arbitrarily to the geometrical orgin so that phi = V.dot(WindDirectio) x point_position
+*     is set arbitrarily to the geometrical origin so that phi = V.dot(WindDirectio) x point_position
 * Only a flat wake is considered. Wake roll-up has been tested but did not prove robust enough for implementation.
 */
 void PanelAnalysis::createWakeContribution(double *pWakeContrib, const Vector3d &WindDirection)
@@ -1568,7 +1568,7 @@ void PanelAnalysis::computePlane(double Alpha, double QInf, int qrhs)
 
         if(m_bPointOut) s_bWarning = true;
 
-        if(m_pWPolar->isStabilityPolar()) m_Alpha = m_AlphaEq; // so it is set by default at the end of the analyis
+        if(m_pWPolar->isStabilityPolar()) m_Alpha = m_AlphaEq; // so it is set by default at the end of the analysis
 
         PlaneOpp *pPOpp = createPlaneOpp(m_Cp+qrhs*m_MatSize, Mu, Sigma);
         m_PlaneOppList.append(pPOpp);
@@ -1580,7 +1580,7 @@ void PanelAnalysis::computePlane(double Alpha, double QInf, int qrhs)
 
 
 /**
-* Returns the estimation of the panel's lift coeficient based on the vortex circulation.
+* Returns the estimation of the panel's lift coefficient based on the vortex circulation.
 * @param p the index of the panel
 * @param Gamma the pointer to the array of vortex circulations
 * @param Cp a pointer to the array of resulting panel lift coefficients
@@ -1772,7 +1772,7 @@ void PanelAnalysis::getDoubletDerivative(const int &p, double const*Mu, double &
 
 
 /**
-* Calculates the Cp coefficient on each panel, using hte vortex circulations or the doublet strengths, depending on the analysis method.
+* Calculates the Cp coefficient on each panel, using the vortex circulations or the doublet strengths, depending on the analysis method.
 * @param V0 the first value in the sequence, either aoa for type 1 & 2 polars or velocity for type 4
 * @param VDelta the increment value of the input parameter, either aoa for type 1 & 2 polars or velocity for type 4
 * @param nval the number of values in the sequence
@@ -2653,7 +2653,7 @@ bool PanelAnalysis::controlLoop()
 
 /**
 * Extracts the eigenvalues and eigenvectors from the state matrices.
-* Stores the results in the memeber variables if successful.
+* Stores the results in the member variables if successful.
 * @return true if the extraction was successful.
 */
 bool PanelAnalysis::solveEigenvalues()
@@ -4610,7 +4610,7 @@ void PanelAnalysis::rotateGeomZ(double Beta, Vector3d const &P, int NXWakePanels
  * @param pPanel a pointer to the array of surface panels to be rotated
  * @param pNode  a pointer to the array of mesh nodes to be rotated
  * @param t the value of the control parameter which defines the amount of rotation
- * @param &NCtrls counts tha active controls
+ * @param &NCtrls counts the active controls
  * @param &out the output message for the log file
  * @param bBCOnly, if true, then only the control points and normal vector and rotates; if not,the whole geometry is rotated
  */
@@ -4807,7 +4807,7 @@ void PanelAnalysis::setControlPositions(double t, int &NCtrls, QString &out, boo
 *    \/          \/
 *
 *
-* Returns the velocity greated by a horseshoe vortex with unit circulation at a distant point
+* Returns the velocity created by a horseshoe vortex with unit circulation at a distant point
 *
 * Notes :
 *  - The geometry has been rotated by the sideslip angle, hence, there is no need to align the trailing vortices with sideslip
@@ -4980,7 +4980,7 @@ void PanelAnalysis::VLMCmn(Vector3d const &A, Vector3d const &B, Vector3d const 
 *    TA__________TB
 *
 *
-* Returns the velocity greated by a ring vortex with unit circulation at a distant point
+* Returns the velocity created by a ring vortex with unit circulation at a distant point
 *
 * Notes :
 *  - The geometry has been rotated by the sideslip angle, hence, there is no need to align the trailing vortices with sideslip

--- a/xflr5v6/xflanalysis/plane_analysis/panelanalysis.h
+++ b/xflr5v6/xflanalysis/plane_analysis/panelanalysis.h
@@ -146,7 +146,7 @@ class PanelAnalysis : QObject
         static bool s_bTrefftz;     /**< /true if the forces should be evaluated in the far-field plane rather than by on-body summation of panel forces */
         static bool s_bKeepOutOpp;  /**< true if points with viscous interpolation issues should be stored nonetheless */
 
-        int s_MaxRHSSize;    /**< the max number of RHS points, used for memeory allocation >*/
+        int s_MaxRHSSize;    /**< the max number of RHS points, used for memory allocation >*/
         int m_MaxMatSize;    /**< the size currently allocated for the influence matrix >*/
 
         static int s_MaxWakeIter;                 /**< wake roll-up iteration limit */

--- a/xflr5v6/xflanalysis/plane_analysis/planetask.cpp
+++ b/xflr5v6/xflanalysis/plane_analysis/planetask.cpp
@@ -291,7 +291,7 @@ WPolar* PlaneTask::setWPolarObject(Plane *pCurPlane, WPolar *pCurWPolar)
  *         body
  *
  * A copy of the panels is saved to the MemPanel and MemNode arrays
- *@return true if successful, false if the panels could not be properly created ot if no object is active
+ *@return true if successful, false if the panels could not be properly created or if no object is active
 */
 bool PlaneTask::initializePanels()
 {
@@ -307,7 +307,7 @@ bool PlaneTask::initializePanels()
     {
 //        Trace(QString("PlaneTask::Requesting additional memory for %1 panels").arg(PanelArraySize));
 
-        // allocate 10% more than needed to avoid repeating the operation if the user requirement increases sightly again.
+        // allocate 10% more than needed to avoid repeating the operation if the user requirement increases slightly again.
         m_MaxPanelSize = int(double(PanelArraySize) *1.1);
         releasePanelMemory();
 

--- a/xflr5v6/xflcore/mathelem.cpp
+++ b/xflr5v6/xflcore/mathelem.cpp
@@ -412,9 +412,9 @@ bool isOdd(int n)
 }
 
 
-/** input uniformly spaced in [0,1], ouput bunched in [0,1]
+/** input uniformly spaced in [0,1], output bunched in [0,1]
     BunchAmp:  k=0.0 --> uniform bunching, k=1-->full varying bunch
-    BunchDist: k=0.0 --> uniform bunching, k=1 weigth on endpoints
+    BunchDist: k=0.0 --> uniform bunching, k=1 weight on endpoints
 */
 double bunchedParameter(double bunchdist, double bunchamp, double t)
 {
@@ -441,7 +441,7 @@ double bunchedParameter(double bunchdist, double bunchamp, double t)
 }
 
 /** Performs a linear regression of the array of n points (x_i, y_i) and
- * calculater the coefficients of line y = ax+b.
+ * calculates the coefficients of line y = ax+b.
  * Returns true if the line could be calculated, false if not */
 bool linearRegression(int n, double const *x, double const*y, double &a, double &b)
 {

--- a/xflr5v6/xflcore/matrix.cpp
+++ b/xflr5v6/xflcore/matrix.cpp
@@ -84,7 +84,7 @@ int Compare(complex<double> a, complex<double>b)
 /**
 * Bubble sort algorithm for complex numbers
 *@param array the array of complex numbers to sort
-*@param ub the size of the aray
+*@param ub the size of the array
 */
 void ComplexSort(complex<double>*array, int ub)
 {

--- a/xflr5v6/xflcore/xflcore.cpp
+++ b/xflr5v6/xflcore/xflcore.cpp
@@ -915,7 +915,7 @@ void xfl::listSysInfo(QString &info)
     info += "\n";
 
 
-    info += "MAC adresses:";
+    info += "MAC addresses:";
     foreach(QNetworkInterface netInterface, QNetworkInterface::allInterfaces())
     {
         // Return only the first non-loopback MAC Address

--- a/xflr5v6/xflgeom/geom2d/segment2d.cpp
+++ b/xflr5v6/xflgeom/geom2d/segment2d.cpp
@@ -57,7 +57,7 @@ bool Segment2d::isEncroachedBy(Vector2d const &pt) const
     return d2<r2-PRECISION;
 }
 
-/** shold'nt be needed */
+/** shouldn't be needed */
 bool Segment2d::isEncroachedBy(Triangle2d const &t2d) const
 {
     Vector2d CC;

--- a/xflr5v6/xflgeom/geom2d/triangle2d.cpp
+++ b/xflr5v6/xflgeom/geom2d/triangle2d.cpp
@@ -413,7 +413,7 @@ bool Triangle2d::contains(Vector2d pt, bool bEdgesInside) const
 
 
 /**
- * Determines if the point with ccordinates (x,y) is inside the triangle or not.
+ * Determines if the point with coordinates (x,y) is inside the triangle or not.
  * @param bEdgesInside if true, points on the edges are considered to be inside the triangle
  * @return  true if the point is inside the triangle, false otherwise
  */

--- a/xflr5v6/xflgeom/geom3d/frame.cpp
+++ b/xflr5v6/xflgeom/geom3d/frame.cpp
@@ -122,7 +122,7 @@ bool Frame::removePoint(int n)
 
 /**
 *Inserts a new point at a specified index in the array of control points.
-* the point is inserted at a mid position between the two adjacent points, or positioned 1/5 of hte distance of the last two points in the array.
+* the point is inserted at a mid position between the two adjacent points, or positioned 1/5 of the distance of the last two points in the array.
 *@param n the index at which a new points will be inserted
 */
 void Frame::insertPoint(int n)

--- a/xflr5v6/xflgeom/geom3d/nurbssurface.cpp
+++ b/xflr5v6/xflgeom/geom3d/nurbssurface.cpp
@@ -27,7 +27,7 @@
 
 /**
  * The public constructor.
- * @param iAxis defines along which preferred axis the paramater u is directed; v is in the y-direction
+ * @param iAxis defines along which preferred axis the parameter u is directed; v is in the y-direction
  */
 NURBSSurface::NURBSSurface(int iAxis)
 {

--- a/xflr5v6/xflgeom/geom3d/triangle3d.cpp
+++ b/xflr5v6/xflgeom/geom3d/triangle3d.cpp
@@ -263,7 +263,7 @@ void Triangle3d::displayNodes(const QString &msg) const
 
 /**
 * Finds the intersection point of a line segment with the triangle.
-* The segement is defined by its two endpoints
+* The segment is defined by its two endpoints
 * @param A the segment's first end point
 * @param B the segment's second end point
 * @param I the intersection point

--- a/xflr5v6/xflgraph/containers/legendwt.cpp
+++ b/xflr5v6/xflgraph/containers/legendwt.cpp
@@ -122,7 +122,7 @@ QSize LegendWt::sizeHint() const
 /**
 * Draws the legend of the polar graphs
 *@param painter the instance of the QPainter object associated to the active view
-*@param the top left postition where the legend is to be drawn
+*@param the top left position where the legend is to be drawn
 *@param the y coordinate of the bottom of the drawing rectangle
 */
 void LegendWt::drawWPolarLegend(QPainter &painter, QPointF place, int bottom)
@@ -203,7 +203,7 @@ void LegendWt::drawWPolarLegend(QPainter &painter, QPointF place, int bottom)
             }
             else
             {
-                // move rigth if outside screen
+                // move right if outside screen
                 place.rx() += LegendWidth;
                 ny=1;
                 painter.setPen(TextPen);
@@ -260,7 +260,7 @@ void LegendWt::drawWPolarLegend(QPainter &painter, QPointF place, int bottom)
 /**
 * Draws the curve legend for the graphs in the operating point view
 * @param painter the instance of the QPainter object associated to the active view
-* @param the top left postition where the legend is to be drawn
+* @param the top left position where the legend is to be drawn
 * @param the y coordinate of the bottom of the drawing rectangle
 */
 void LegendWt::drawPOppGraphLegend(QPainter &painter, QPointF place, double bottom)
@@ -417,7 +417,7 @@ void LegendWt::drawPOppGraphLegend(QPainter &painter, QPointF place, double bott
 /**
 * Draws the legend of the Cp graph
 *@param painter the instance of the QPainter object associated to the active view
-*@param the top left postition where the legend is to be drawn
+*@param the top left position where the legend is to be drawn
 *@param the y coordinate of the bottom of the drawing rectangle
 */
 void LegendWt::drawCpLegend(QPainter &painter, Graph const *pGraph, QPointF place, int bottom)
@@ -481,7 +481,7 @@ void LegendWt::drawCpLegend(QPainter &painter, Graph const *pGraph, QPointF plac
 /**
 * Draws the legend for the time response graph- 4 curves
 *@param painter the instance of the QPainter object associated to the active view
-*@param the top left postition where the legend is to be drawn
+*@param the top left position where the legend is to be drawn
 *@param the y coordinate of the bottom of the drawing rectangle
 */
 void LegendWt::drawStabTimeLegend(QPainter &painter, Graph const *pGraph, QPointF place, int bottom)
@@ -610,7 +610,7 @@ void LegendWt::drawPolarLegend(QPainter &painter, QPointF place, int bottom)
             }
             else if (k>0)
             {
-                // move rigth if less than client bottom area
+                // move right if less than client bottom area
                 place.rx() += LegendWidth;
                 ny=1;
             }

--- a/xflr5v6/xflobjects/editors/wingdlg.cpp
+++ b/xflr5v6/xflobjects/editors/wingdlg.cpp
@@ -1538,7 +1538,7 @@ bool WingDlg::VLMSetAutoMesh(int total)
 
     if(!total)
     {
-        size = 2000/4;//why not ? Too much refinement isn't worthwile
+        size = 2000/4;//why not ? Too much refinement isn't worthwhile
         NYTotal = 22;
     }
     else

--- a/xflr5v6/xflobjects/objects2d/foil.cpp
+++ b/xflr5v6/xflobjects/objects2d/foil.cpp
@@ -93,7 +93,7 @@ Foil::Foil()
 /**
 * Constructs the position of the foil's mid camber line.
 * Calculates the foil's thickness and camber, if requested.
-*@param bParams true if the max thickness and camber properties shold be calculated
+*@param bParams true if the max thickness and camber properties should be calculated
 */
 void Foil::compMidLine(bool bParams)
 {
@@ -137,7 +137,7 @@ void Foil::compMidLine(bool bParams)
 
 /**
 * Copies the data from an existing foil and maps it to this foil's variables.
-* @param pSrcFoil a pointer to the reference foil from which the data wil be copied
+* @param pSrcFoil a pointer to the reference foil from which the data will be copied
 */
 void Foil::copyFoil(const Foil *pSrcFoil, bool bMetaData)
 {
@@ -760,7 +760,7 @@ int Foil::isPoint(Vector2d const &Real) const
 }
 
 /**
-* Normalizes the base foil's lengh to unity.
+* Normalizes the base foil's length to unity.
 * The current foil's length is modified by the same ratio.
 * @return the foil's former length
 */

--- a/xflr5v6/xflobjects/objects2d/objects2d.cpp
+++ b/xflr5v6/xflobjects/objects2d/objects2d.cpp
@@ -163,7 +163,7 @@ void Objects2d::insertThisFoil(Foil *pFoil)
     {
         if(pFoil == s_oaFoil.at(iFoil))
         {
-            //            Trace("This foil "+m_FoilName+" aready exists and has not been inserted");
+            //            Trace("This foil "+m_FoilName+" already exists and has not been inserted");
             return;
         }
     }

--- a/xflr5v6/xflobjects/objects2d/opppoint.cpp
+++ b/xflr5v6/xflobjects/objects2d/opppoint.cpp
@@ -296,7 +296,7 @@ bool OpPoint::serializeOppWPA(QDataStream &ar, bool bIsStoring, int ArchiveForma
 
     if(bIsStoring)
     {
-        /** deprecated, we dont't store in .wpa format anymore */
+        /** deprecated, we don't store in .wpa format anymore */
     }
     else
     {

--- a/xflr5v6/xflobjects/objects3d/body.cpp
+++ b/xflr5v6/xflobjects/objects3d/body.cpp
@@ -249,7 +249,7 @@ double Body::length() const
 
 
 /**
- * Returns the posistion of the Body nose
+ * Returns the position of the Body nose
  * @return the Vector3d which defines the position of the Body nose.
  */
 Vector3d Body::leadingPoint() const
@@ -274,7 +274,7 @@ double Body::getSectionArcLength(double x) const
 {
     //NURBS only
     if(m_LineType==xfl::BODYPANELTYPE) return 0.0;
-    // aproximate arc length, used for inertia estimations
+    // approximate arc length, used for inertia estimations
     double length = 0.0;
     double ux = getu(x);
     Vector3d Pt, Pt1;
@@ -334,7 +334,7 @@ Vector3d Body::Point(double u, double v, bool bRight) const
 /**
  * Returns the value of the longitudinal parameter given the absolute X-position ON the NURBS surface.
  * @param x in input, the longitudinal position
- * @return the longitudinal paramater on the NURBS surface
+ * @return the longitudinal parameter on the NURBS surface
  */
 double Body::getu(double x) const
 {
@@ -343,7 +343,7 @@ double Body::getu(double x) const
 
 /**
  * For a NURBS surface: Given a value of the longitudinal parameter and a vector in the yz plane, returns the
- * value of the hoop paramater for the intersection of a ray originating on the x-axis
+ * value of the hoop parameter for the intersection of a ray originating on the x-axis
  * and directed along the input vector
  * @param u in input, the value of the longitudinal parameter
  * @param r the vector which defines the ray's direction

--- a/xflr5v6/xflobjects/objects3d/panel.h
+++ b/xflr5v6/xflobjects/objects3d/panel.h
@@ -103,11 +103,11 @@ class Panel
 
 
     protected:
-        bool m_bIsInSymPlane;    /**< true if the panel lies in the plane's xz plane of symetry at y=0*/
+        bool m_bIsInSymPlane;    /**< true if the panel lies in the plane's xz plane of symmetry at y=0*/
         bool m_bIsLeftPanel;     /**< true if the panel lies on the left (port) wing */
         bool m_bIsWakePanel;     /**< true if the panel lies on the wake of a winf */
 
-        int m_iElement;          /**< panel identification number ; used when the panel array is re-arranged in non sequential order to reduce the matrix size in symetrical calculations */
+        int m_iElement;          /**< panel identification number ; used when the panel array is re-arranged in non sequential order to reduce the matrix size in symmetrical calculations */
         int m_iPL;               /**< index of the panel which lies left of this panel, or -1 if none */
         int m_iPR;               /**< index of the panel which lies right of this panel, or -1 if none */
         int m_iPU;               /**< index of the panel which lies upstream of this panel, or -1 if none */
@@ -115,7 +115,7 @@ class Panel
         int m_iWake;             /**< -1 if not followed by a wake panel, else equal to wake panel number */
         int m_iWakeColumn;       /**< index of the wake column shed by this panel, numbered from left tip to right tip, or -1 if none */
 
-        //Local frame of refernce
+        //Local frame of reference
         Vector3d VortexPos;       /**< the absolute position of the mid point of the bound vortex at the panel's quarter chord */
         Vector3d Vortex;          /**< the bound vortex vector at the panel's quarter chord */
         Vector3d P1;              /**< the coordinates of the panel's corners, in local coordinates */

--- a/xflr5v6/xflobjects/objects3d/plane.cpp
+++ b/xflr5v6/xflobjects/objects3d/plane.cpp
@@ -490,7 +490,7 @@ void Plane::createSurfaces()
 
 
 /**
-* Initiliazes the pointer to an existing Body object
+* Initializes the pointer to an existing Body object
 * @param pBody the pointer to the existing Body object
 */
 void Plane::setBody(Body *pBody)

--- a/xflr5v6/xflobjects/objects3d/plane.h
+++ b/xflr5v6/xflobjects/objects3d/plane.h
@@ -206,7 +206,7 @@ class Plane : public XflObject
         double m_TailVolume;                        /**< the tail volume, i.e lever_arm_elev x Area_Elev / MAC_wing / Area_wing */
         Vector3d m_CoG;                             /**< the position of the CoG */
 
-        Vector3d m_WingLE[MAXWINGS];                /**< the array of the leading edge postion of each Wing */
+        Vector3d m_WingLE[MAXWINGS];                /**< the array of the leading edge position of each Wing */
         double m_WingTiltAngle[MAXWINGS];           /**< the rotation in degrees of each Wing about the y-axis */
         Vector3d m_BodyPos;                         /**< the translation vector to apply to the Body */
 

--- a/xflr5v6/xflobjects/objects3d/surface.cpp
+++ b/xflr5v6/xflobjects/objects3d/surface.cpp
@@ -355,7 +355,7 @@ void Surface::getTrailingPt(int k, Vector3d &C) const
 
 /**
  * Calculates the corner points of the panel with index k in the span direction and index l in the chordwise direction.
- * The point coordinates are loaded in the memeber variables LA, LB, TA, TB.
+ * The point coordinates are loaded in the member variables LA, LB, TA, TB.
  *
  * Assumes the side points have been set previously
  *

--- a/xflr5v6/xflobjects/objects3d/surface.h
+++ b/xflr5v6/xflobjects/objects3d/surface.h
@@ -204,7 +204,7 @@ class Surface
         static Panel *s_pPanel;    /**< a pointer to the array of this Surface's panels, This array is a sub-array of the total array.*/
         static Vector3d *s_pNode;   /**< a pointer to the array of this panel nodes.*/
 
-        bool m_bIsInSymPlane;      /**< true if the Surface is positioned in the symetry xz plane defined by y=0. Case of a single fin. */
+        bool m_bIsInSymPlane;      /**< true if the Surface is positioned in the symmetry xz plane defined by y=0. Case of a single fin. */
         bool m_bTEFlap;            /**< true if the Surface has a flap on the trailing edge */
         bool m_bIsLeftSurf;        /**< true if the Surface is built on the left wing */
         bool m_bIsRightSurf;       /**< true if the Surface is built on the right wing */
@@ -223,7 +223,7 @@ class Surface
         xfl::enumPanelDistribution m_YDistType;            /**< the type of distribution along the Surface's y axis */
         int m_NXLead;               /**< the number of panels upstream of the flap, i.e. between the leading edge and the hinge */
         int m_NXFlap;               /**< the number of panels on the flap, i.e. between the hinge and the trailing edge */
-        int m_NElements;            /**< the number of panel elements constructer on this Surface. */
+        int m_NElements;            /**< the number of panel elements constructor on this Surface. */
 
         int m_nFlapNodes;           /**< the number of nodes defined on the trailing edge flap */
         int m_nFlapPanels;          /**< the number of panels defined on the trailing edge flap */

--- a/xflr5v6/xflobjects/objects3d/wing.cpp
+++ b/xflr5v6/xflobjects/objects3d/wing.cpp
@@ -614,7 +614,7 @@ void Wing::computeBodyAxisInertia()
  * The surfaces are constructed from root to tip, and re-ordered from left tip to right tip
  * One surface object for each of the wing's panels
  * A is the surface's left side, B is the right side
- * @param T the translation to be appied to the wing geometry
+ * @param T the translation to be applied to the wing geometry
  * @param XTilt  the rotation in degrees around the x-axis; used in the case of fins
  * @param YTilt  the rotation in degrees arouns the y-axis; used for wing or elevator tilt
  */
@@ -754,8 +754,8 @@ void Wing::createSurfaces(Vector3d const &T, double XTilt, double YTilt)
 
     // we only need a right wing in the following cases
     //   - if it's an 'ordinary wing'
-    //   - if it's a fin, symetrical about the fuselage x-axis
-    //   - if it's a symetrical double fin
+    //   - if it's a fin, symmetrical about the fuselage x-axis
+    //   - if it's a symmetrical double fin
     if(!m_bIsFin || (m_bIsFin && m_bSymFin) || (m_bIsFin && m_bDoubleFin))
     {
         m_Surface[NSurfaces].m_bIsCenterSurf   = true;//next right center surface
@@ -847,7 +847,7 @@ void Wing::createSurfaces(Vector3d const &T, double XTilt, double YTilt)
         if(m_bDoubleFin)
         {
             NSurfaces*=2;
-            //rotate surfaces symetrically
+            //rotate surfaces symmetrically
             int ns2 = int(NSurfaces/2);
             offset.set(0.0, -T.y, 0.0);
             for(int jSurf=0; jSurf<ns2; jSurf++)
@@ -1030,7 +1030,7 @@ void Wing::computeChords(int NStation, double *chord, double *offset, double *tw
 
 
 /**
-* Copies the gemetrical data from an existing Wing
+* Copies the geometrical data from an existing Wing
 *@param pWing a pointer to the instance of the source Wing object
 */
 void Wing::duplicate(Wing const*pWing)
@@ -1081,7 +1081,7 @@ void Wing::duplicate(Wing const*pWing)
 
 /**
 * Returns the wing's average sweep from root to tip measured at the quarter chord
-* The sweep is calulated as the arctangent of the root and tip quarter-chord points
+* The sweep is calculated as the arctangent of the root and tip quarter-chord points
 *@return the value of the average sweep, in degrees
 */
 double Wing::averageSweep() const
@@ -1323,7 +1323,7 @@ double Wing::yrel(double SpanPos) const
 /**
  * The z-position of a specified absolute span position.
  * Used for moment evaluations in LLT, where the wing is defined as a 2D planform
- * @param y the abolute span position
+ * @param y the absolute span position
  * @return the absolute z-position
  */
 double Wing::zPos(double y) const
@@ -1882,7 +1882,7 @@ void Wing::removeWingSection(int const iSection)
 
 
 /**
- * Inserts a section in the geometry of the wing at a postion identified by its index
+ * Inserts a section in the geometry of the wing at a position identified by its index
  * @param iSection the index of the section
  */
 void Wing::insertSection(int iSection)
@@ -4264,7 +4264,7 @@ uint32_t Wing::exportSTL3dPrintable(QDataStream &outStreamData, QTextStream &out
                                 printOutputStyle outputStyle, float unit)
 {
 
-    // 3d printers expect measurements in mm, no the normal xflr5 SI units, so multiply ouput by 1000
+    // 3d printers expect measurements in mm, no the normal xflr5 SI units, so multiply output by 1000
     unit = 1000;
 
 

--- a/xflr5v6/xflobjects/objects3d/wing.h
+++ b/xflr5v6/xflobjects/objects3d/wing.h
@@ -388,7 +388,7 @@ class Wing
         double m_CDi;                    /**< the wing's induced drag coefficient for the current calculation */
         double m_CDv;                    /**< the wing's viscous drag coefficient for the current calculation */
         double m_WingCL;                     /**< the lift coefficient */
-        double m_Maxa;                   /**< the convergence crtierion on the difference of induced angle at any span bewteen two LLT iterations*/
+        double m_Maxa;                   /**< the convergence crtierion on the difference of induced angle at any span between two LLT iterations*/
         double m_ICm;                    /**< the induced par of the pitching moment coefficient */
         double m_GCm;                    /**< the total pitching moment coefficient */
         double m_VCm;                    /**< the viscous part of the pitching moment coefficient */
@@ -451,7 +451,7 @@ class Wing
         Vector3d m_CoG;                            /**< the position of the CoG */
 
         int m_FirstPanelIndex;                          /**< the index of this wing's first panel in the array of panels */
-        int m_nPanels;                             /**< the number of mesh panels on this Wing; dependant on the polar type */
+        int m_nPanels;                             /**< the number of mesh panels on this Wing; dependent on the polar type */
 
         static QVector<Foil*> *s_poaFoil;
         static QVector<Polar*> *s_poaPolar;

--- a/xflr5v6/xflobjects/objects3d/wingopp.cpp
+++ b/xflr5v6/xflobjects/objects3d/wingopp.cpp
@@ -152,7 +152,7 @@ bool WingOpp::exportWOpp(QTextStream &out, bool bCSV)
 
 /**
  * Returns the maximum value of the local lift along the span.
- * Used to calibrate the display of the optimal elliptic curve in hte WingOpp graph.
+ * Used to calibrate the display of the optimal elliptic curve in the WingOpp graph.
  * @return the maximum local lift.
 */
 double WingOpp::maxLift() const

--- a/xflr5v6/xflobjects/objects3d/wingopp.h
+++ b/xflr5v6/xflobjects/objects3d/wingopp.h
@@ -37,7 +37,7 @@
 *@brief
 *    This class implements the operating point object which stores the data of plane analysis
 *
-    In the case of an analysis of an independant wing, the instance of this WingOpp class is
+    In the case of an analysis of an independent wing, the instance of this WingOpp class is
     uniquely associated to an instance of a WPolar, which is itself uniquely associated to the Wing object.
     Alternatively, the WingOpp may be a member variable of a PlaneOpp object.
     The data is stored in International Standard Units, i.e. meters, seconds, kg, and Newtons.
@@ -148,8 +148,8 @@ public:
     double m_XCPSpanRel[MAXSPANSTATIONS+1]; /**< the relative position of the centre of pressure on each chordwise strip, in chord % */
     double m_XCPSpanAbs[MAXSPANSTATIONS+1]; /**< the absolute position of the centre of pressure on each chordwise strip */
     double m_StripArea[MAXSPANSTATIONS+1];  /**< the area of the chordwise strips */
-    double m_XTrTop[MAXSPANSTATIONS+1];     /**< the transition location on the top surface*/
-    double m_XTrBot[MAXSPANSTATIONS+1];     /**< the transition location on the bottom suface */
+    double m_XTrTop[MAXSPANSTATIONS+1];     /**< the transition location on the top surface */
+    double m_XTrBot[MAXSPANSTATIONS+1];     /**< the transition location on the bottom surface */
 
     QVector<double> m_FlapMoment;   /**< the flap hinge moments */
 

--- a/xflr5v6/xflobjects/objects3d/wingsection.h
+++ b/xflr5v6/xflobjects/objects3d/wingsection.h
@@ -75,7 +75,7 @@ public:
     double m_Chord;         /**< Chord length at each panel side */
     double m_Length;        /**< the length of each panel */
     double m_YPosition;     /**< b-position of each panel end on developed surface */
-    double m_YProj;         /**< b-position of each panel end projected on tbe xy plane */
+    double m_YProj;         /**< b-position of each panel end projected on the xy plane */
     double m_Offset;        /**< b-position of each panel end */
     double m_Dihedral;      /**< b-position of each panel end */
     double m_ZPos;          /**< vertical offset - calculation result only */

--- a/xflr5v6/xflobjects/objects3d/wpolar.h
+++ b/xflr5v6/xflobjects/objects3d/wpolar.h
@@ -199,7 +199,7 @@ class WPolar : public XflObject
         int      m_PolarFormat;        /**< the identification number which references the format used to serialize the data */
 
         xfl::enumBC m_BoundaryCondition;
-        xfl::enumRefDimension  m_ReferenceDim;        /**< Describes the origin of the refernce area : 1 if planform area, else projected area */
+        xfl::enumRefDimension  m_ReferenceDim;        /**< Describes the origin of the reference area : 1 if planform area, else projected area */
 
         QString  m_PlaneName;          /**< the name of the parent wing or plane */
 
@@ -281,7 +281,7 @@ class WPolar : public XflObject
 
         QVector <double>  m_XCpCl;                   /**< XCp.Cl, used in calculation of neutral point position >*/
         QVector <double>  m_SM;                      /**< (XCP-XCmRef)/m.a.c; >*/
-        QVector <double>  m_TCd;                     /**< the total drag coeficient >*/
+        QVector <double>  m_TCd;                     /**< the total drag coefficient >*/
         QVector <double>  m_VCm;                     /**< the viscous Pitching Moment coefficient >*/
         QVector <double>  m_VertPower;               /**< the power for steady horizontal flight = m.g.Vz >*/
         QVector <double>  m_HorizontalPower;         /**< the power for steady horizontal flight = Fx.Vx >*/

--- a/xflr5v6/xflobjects/objects_global.cpp
+++ b/xflr5v6/xflobjects/objects_global.cpp
@@ -452,7 +452,7 @@ void xfl::drawFoil(QPainter &painter, Foil const*pFoil, double alpha, double sca
 
 /**
  * Draws the foil's mid line in the client area.
- * @param painter a refernce to the QPainter object on which the foil will be drawn
+ * @param painter a reference to the QPainter object on which the foil will be drawn
  * @param alpha the rotation angle in degrees of the foil
  * @param scalex the scaling factor in the x-direction
  * @param scaley the scaling factor in the y-direction

--- a/xflr5v6/xflscript/resources/foil_script.xml
+++ b/xflr5v6/xflscript/resources/foil_script.xml
@@ -79,7 +79,7 @@
         <Batch_Analysis_Data>
             <!-- Polar_Type is either 1, 2, 3 or 4-->
             <Polar_Type>1</Polar_Type>
-            <!-- For type 1 to 3 polars, set the field Spec_Alpha to true if runnning a range of aoa,
+            <!-- For type 1 to 3 polars, set the field Spec_Alpha to true if running a range of aoa,
                  or to false if running a range of lift coefficients. -->
 
             <!-- Specify the forced transition locations for the analysis -->

--- a/xflr5v6/xflwidgets/exponentialslider.cpp
+++ b/xflr5v6/xflwidgets/exponentialslider.cpp
@@ -23,7 +23,7 @@
 
 #include <cmath>
 
-//caution, use only for "symetrical" sliders ranging from -range to +range
+//caution, use only for "symmetrical" sliders ranging from -range to +range
 
 ExponentialSlider::ExponentialSlider(QWidget * pParent)
 {

--- a/xflr5v6/xflwidgets/view/section2dwt.h
+++ b/xflr5v6/xflwidgets/view/section2dwt.h
@@ -148,7 +148,7 @@ class Section2dWt : public QWidget
 
         QPointF m_ptOffset;          /**< the foil's leading edge position in screen coordinates */
         QPointF m_ViewportTrans;     /**< the translation of the viewport */
-        QPoint m_PointDown;         /**< the screen point where the last left-click occured */
+        QPoint m_PointDown;         /**< the screen point where the last left-click occurred */
 
         QRect m_ZoomRect;           /**< the user-defined rectangle for zooming in */
 

--- a/xflr5v6/xinverse/foilselectiondlg.cpp
+++ b/xflr5v6/xinverse/foilselectiondlg.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 
-    FoilSelectionDlg Classe
+    FoilSelectionDlg Classes
     Copyright (C)  André Deperrois
 
     This program is free software; you can redistribute it and/or modify

--- a/xflr5v6/xinverse/foilselectiondlg.h
+++ b/xflr5v6/xinverse/foilselectiondlg.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 
-    FoilSelectionDlg Classe
+    FoilSelectionDlg Classes
     Copyright (C) André Deperrois
 
     This program is free software; you can redistribute it and/or modify

--- a/xflr5v6/xinverse/pertdlg.cpp
+++ b/xflr5v6/xinverse/pertdlg.cpp
@@ -33,7 +33,7 @@
 
 PertDlg::PertDlg(QWidget *pParent) : QDialog(pParent)
 {
-    setWindowTitle(tr("Pertubation Dialog"));
+    setWindowTitle(tr("Perturbation Dialog"));
     m_pXInverse = pParent;
     memset(m_cnr,   0, sizeof(m_cnr));
     memset(m_cni,   0, sizeof(m_cni));

--- a/xflr5v6/xinverse/xinverse.cpp
+++ b/xflr5v6/xinverse/xinverse.cpp
@@ -52,7 +52,7 @@
 MainFrame *XInverse::s_pMainFrame;
 inverseviewwt *XInverse::s_p2dWidget;
 
-/** The public contructor */
+/** The public constructor */
 XInverse::XInverse(QWidget *parent)
     : QWidget(parent)
 {
@@ -487,7 +487,7 @@ bool XInverse::execQDES()
 /**
  * Initializes XFoil with the data from the input Foil object
  * @param pFoil a pointer to the Foil object with which to initialize the XFoil object
- * @true if the initialization has been sucessful
+ * @true if the initialization has been successful
  */
 bool XInverse::initXFoil(Foil * pFoil)
 {
@@ -2759,9 +2759,9 @@ void XInverse::setupLayout()
 
 
 /**
- * Performs a smoothing operation of the specification cuve between two end points
+ * Performs a smoothing operation of the specification curve between two end points
  * @param Pos1 the first end point
- * @param Pos2 the seconf end point
+ * @param Pos2 the second end point
  */
 void XInverse::smooth(int Pos1, int Pos2)
 {

--- a/xflr5v6/xinverse/xinverse.h
+++ b/xflr5v6/xinverse/xinverse.h
@@ -184,7 +184,7 @@ class XInverse : public QWidget
         Foil *m_pModFoil;           /**< a pointer to the resulting Foil modified by inverse design operations */
         Foil const *m_pOverlayFoil;
 
-        Spline5 m_Spline;            /**< the spline oject to modify the velocity curve */
+        Spline5 m_Spline;            /**< the spline object to modify the velocity curve */
 
         bool m_bXPressed;           /**< true if the 'X' key is pressed */
         bool m_bYPressed;           /**< true if the 'Y' key is pressed */


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,./**/*_fr.tex -L ans,blong,dum,herat,ist,pevent,pres,te,thck,thi,ue`